### PR TITLE
in Keras 2.2.0 vgg16 have different layer index

### DIFF
--- a/cnn_class2/style_transfer3.py
+++ b/cnn_class2/style_transfer3.py
@@ -77,8 +77,8 @@ vgg = VGG16_AvgPool(shape)
 # create the content model
 # we only want 1 output
 # remember you can call vgg.summary() to see a list of layers
-# 1,2,4,5,7-9,11-13,15-17
-content_model = Model(vgg.input, vgg.layers[13].get_output_at(1))
+# 0,1,3,4,6-8,10-12,14-16
+content_model = Model(vgg.input, vgg.layers[12].get_output_at(1))
 content_target = K.variable(content_model.predict(content_img))
 
 


### PR DESCRIPTION
In Keras 2.1.0
vgg.summary()
_________________________________________________________________
Layer (type)                 Output Shape              Param #   
=================================================================
input_1 (InputLayer)         (None, 397, 635, 3)       0         
_________________________________________________________________
block1_conv1 (Conv2D)        (None, 397, 635, 64)      1792      
_________________________________________________________________
block1_conv2 (Conv2D)        (None, 397, 635, 64)      36928     
_________________________________________________________________
........
........
........

But in Keras 2.2.0

vgg.summary()
_________________________________________________________________
Layer (type)                 Output Shape              Param #   
=================================================================
block1_conv1 (Conv2D)        (None, 397, 635, 64)      1792      
_________________________________________________________________
block1_conv2 (Conv2D)        (None, 397, 635, 64)      36928     
_________________________________________________________________
average_pooling2d_1 (Average (None, 198, 317, 64)      0         
_________________________________________________________________

We find that "input_1 (InputLayer) " was missing. So the index of layers were also changed.