### PR TITLE
Update save_a_video.py

### DIFF
--- a/rl2/cartpole/save_a_video.py
+++ b/rl2/cartpole/save_a_video.py
@@ -65,3 +65,5 @@ if __name__ == '__main__':
   # play a final set of episodes
   env = wrappers.Monitor(env, 'my_awesome_dir')
   print("***Final run with final weights***:", play_one_episode(env, params))
+  # close the environment
+  env.env.close()


### PR DESCRIPTION
Added env.env.close() in order to remove the error:

Traceback (most recent call last):
  File "/home/ekele/anaconda3/envs/gpurl/lib/python3.6/site-packages/gym/envs/classic_control/rendering.py", line 143, in __del__
  File "/home/ekele/anaconda3/envs/gpurl/lib/python3.6/site-packages/gym/envs/classic_control/rendering.py", line 62, in close
  File "/home/ekele/anaconda3/envs/gpurl/lib/python3.6/site-packages/pyglet/window/xlib/__init__.py", line 480, in close
  File "/home/ekele/anaconda3/envs/gpurl/lib/python3.6/site-packages/pyglet/gl/xlib.py", line 345, in destroy
  File "/home/ekele/anaconda3/envs/gpurl/lib/python3.6/site-packages/pyglet/gl/base.py", line 334, in destroy
  File "/home/ekele/anaconda3/envs/gpurl/lib/python3.6/site-packages/pyglet/gl/xlib.py", line 335, in detach
  File "/home/ekele/anaconda3/envs/gpurl/lib/python3.6/site-packages/pyglet/gl/lib.py", line 97, in errcheck
ImportError: sys.meta_path is None, Python is likely shutting down