### PR TITLE
docs: fix simple typo, distrbution -> distribution

### DIFF
--- a/svm_class/svm_gradient.py
+++ b/svm_class/svm_gradient.py
@@ -70,7 +70,7 @@ class SVM:
       self.alphas[self.alphas < 0] = 0
       self.alphas[self.alphas > self.C] = self.C
 
-    # distrbution of bs
+    # distribution of bs
     idx = np.where((self.alphas) > 0 & (self.alphas < self.C))[0]
     bs = Y[idx] - (self.alphas * Y).dot(self.kernel(X, X[idx]))
     self.b = np.mean(bs)


### PR DESCRIPTION
There is a small typo in svm_class/svm_gradient.py.

Should read `distribution` rather than `distrbution`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md